### PR TITLE
Minor changes for purposes of testing cosmos sdk

### DIFF
--- a/examples/cosmos-sdk/client.sh
+++ b/examples/cosmos-sdk/client.sh
@@ -8,13 +8,27 @@ ARG_YES=${YES:-"--yes"}
 CHAINID="4040-1"
 MONIKER="localtestnet"
 
-if [ "$1" == "tx" ]; then
-    MORE_ARGS="-b block --fees 100000stake $ARG_YES"
-else
-    MORE_ARGS=""
+generate_tx=false
+MORE_ARGS="" 
+
+if [ "$1" == "tx" ]; 
+then
+    for argument in "$@"
+    do 
+        if [ "$argument" == "--generate-only" ];
+        then	
+            generate_tx=true
+        fi 
+
+    done
+            
+    if [ "$generate_tx" == "false" ]; 
+    then
+    	MORE_ARGS=" -b block --fees 100000stake $ARG_YES"
+    fi      
 fi
 
+CHAIN_ARGS="simd "$@$MORE_ARGS
 
-docker exec -i cosmos-container \
-    /usr/bin/simd "$@" $MORE_ARGS
-# --chain-id "$CHAINID" 
+docker exec -i cosmos-container sh -c "$CHAIN_ARGS"
+#--chain-id "$CHAINID"

--- a/src/atomkraft/cosmos.py
+++ b/src/atomkraft/cosmos.py
@@ -55,9 +55,13 @@ class CosmosCmd(Connector):
                 # if code is 0, then the command was executed successfully
                 self.shlog(f"# return code: {proc.returncode}")
                 if proc.returncode > 0:
-                    for e in errs.split('\n'):
-                        self.shlog('# ' + e)
-                    return False
+                    if errs != None:
+                        for e in errs.split('\n'):
+                            self.shlog('# ' + e)
+                        return False
+                    else:
+                        self.shlog('# Transaction command was not valid. Execution was aborted on CLI.')
+                        return False
                 else:
                     for o in outs.split('\n'):
                         self.shlog('# ' + o)


### PR DESCRIPTION
While working on generating commands from apalache traces, I needed to adapt atomkraft in: 

1. cosmos.py: in order to be able to work with invalid transactions (when transactions are aborted on CLI - no errs is returned, so exception occurred in those cases
2. client.sh: to be able to generate .json file in dockerized chain (containing transaction for purposes of later broadcasting)