### PR TITLE
simd app should start with validator mode flag

### DIFF
--- a/examples/cosmos-sdk/start-node.sh
+++ b/examples/cosmos-sdk/start-node.sh
@@ -10,7 +10,7 @@ MONIKER="localtestnet"
 docker run --rm --name "cosmos-container" \
     -p 0.0.0.0:1317:1317 \
     -i cosmos-image \
-    /usr/bin/simd start \
+    /usr/bin/simd start --mode validator\
     --pruning=nothing \
     --trace \
     --minimum-gas-prices=0.0001stake \


### PR DESCRIPTION
When trying to start simd with current implementation of start-node.sh  there was an issue with creation of blocks.
<details>
  <summary>CLI Output</summary>
  
7:58AM INF not caught up yet height=1 max_peer_height=0 module=blockchain timeout_in=2998.889201
7:58AM INF not caught up yet height=1 max_peer_height=0 module=blockchain timeout_in=1999.420387
7:58AM INF not caught up yet height=1 max_peer_height=0 module=blockchain timeout_in=998.783606
7:58AM ERR no progress since last advance last_advance=2022-05-13T07:57:10Z module=blockchain
7:58AM INF switching to consensus module=consensus
7:58AM INF starting service impl=ConsensusState module=consensus service=State
7:58AM INF starting service impl=baseWAL module=consensus service=baseWAL wal=/root/.simapp/data/cs.wal/wal
7:58AM INF starting service impl=Group module=consensus service=Group wal=/root/.simapp/data/cs.wal/wal
7:58AM INF Searching for height height=1 max=0 min=0 module=consensus wal=/root/.simapp/data/cs.wal/wal
7:58AM INF Searching for height height=0 max=0 min=0 module=consensus wal=/root/.simapp/data/cs.wal/wal
7:58AM INF Found height=0 index=0 module=consensus wal=/root/.simapp/data/cs.wal/wal
7:58AM INF Catchup by replaying consensus messages height=1 module=consensus
7:58AM INF Replay: Done module=consensus
7:58AM INF starting service impl=TimeoutTicker module=consensus service=TimeoutTicker
7:58AM INF Timed out dur=-55006.570699 height=1 module=consensus round=0 step=1
7:58AM INF Timed out dur=3000 height=1 module=consensus round=0 step=3

</details>

So i noticed that simd has been started without any mode flag. 
`simd start` runs the full node and since we need to start the one validator node chain here, it is necessary to pass this flag. (reference to: [#11042](https://github.com/cosmos/cosmos-sdk/issues/11042) )
