### PR TITLE
Hide chain node data

### DIFF
--- a/atomkraft/chain/__init__.py
+++ b/atomkraft/chain/__init__.py
@@ -50,6 +50,10 @@ def config(
                             data = data[int(key)]
             print(json.dumps({property_path: data}, indent=2))
     else:
+        try:
+            value = eval(value)
+        except:
+            pass
         with open(f"{project.project_root()}/chain.toml") as f:
             main_data = tomlkit.load(f)
             if property_path is not None:

--- a/atomkraft/chain/__init__.py
+++ b/atomkraft/chain/__init__.py
@@ -16,7 +16,17 @@ app = typer.Typer()
 
 
 @app.command()
-def config(property_path: str, value: Optional[str] = typer.Argument(None)):
+def config(
+    property_path: str = typer.Argument(
+        ..., help="Nested keys of a config value, joined by `.`", show_default=False
+    ),
+    value: Optional[str] = typer.Argument(
+        None, help="Update old value with provided value"
+    ),
+):
+    """
+    Query or update chain configuration
+    """
     if value is None:
         with open(f"{project.project_root()}/chain.toml") as f:
             data = tomlkit.load(f)
@@ -78,11 +88,16 @@ def config(property_path: str, value: Optional[str] = typer.Argument(None)):
 
 
 @app.command()
-def testnet():
+def testnet(silent: bool = typer.Option(False, help="Silent mode. Print no output")):
+    """
+    Run a testnet in background
+    """
     testnet = Testnet.load_toml(f"{project.project_root()}/chain.toml")
+    testnet.verbose = not silent
 
     testnet.oneshot()
     try:
-        time.sleep(600)
+        while True:
+            time.sleep(1)
     except KeyboardInterrupt:
         print("\ntear-down!")

--- a/atomkraft/chain/__init__.py
+++ b/atomkraft/chain/__init__.py
@@ -6,6 +6,8 @@ import tomlkit
 import typer
 from atomkraft.utils import project
 
+from pathlib import Path
+
 from .node import Account, Coin, ConfigPort, Node
 from .testnet import Testnet
 
@@ -88,12 +90,21 @@ def config(
 
 
 @app.command()
-def testnet(silent: bool = typer.Option(False, help="Silent mode. Print no output")):
+def testnet(
+    silent: bool = typer.Option(False, help="Silent mode. Print no output"),
+    config: Optional[Path] = typer.Option(None, help="Path to chain.toml"),
+):
     """
     Run a testnet in background
     """
-    testnet = Testnet.load_toml(f"{project.project_root()}/chain.toml")
+    if config is None:
+        testnet = Testnet.load_toml(f"{project.project_root()}/chain.toml")
+    else:
+        testnet = Testnet.load_toml(config)
     testnet.verbose = not silent
+    testnet.keep = True
+    testnet.overwrite = True
+    testnet.data_dir = ".atomkraft"
 
     testnet.oneshot()
     try:

--- a/atomkraft/chain/node.py
+++ b/atomkraft/chain/node.py
@@ -99,7 +99,7 @@ class Node:
         self._stderr = None
 
     def init(self):
-        if self.overwrite:
+        if self.overwrite and os.path.exists(self.home_dir):
             shutil.rmtree(self.home_dir)
         args = f"init {self.moniker} --chain-id {self.chain_id}".split()
         _, data = self._execute(args, stderr=PIPE)

--- a/atomkraft/chain/testnet.py
+++ b/atomkraft/chain/testnet.py
@@ -29,6 +29,7 @@ class Testnet:
         overwrite=False,
         keep=False,
         verbose=False,
+        data_dir=None,
     ):
         self.chain_id = chain_id
         self.n_validator = n_validator
@@ -44,6 +45,7 @@ class Testnet:
         self.overwrite = overwrite
         self.keep = keep
         self.verbose = verbose
+        self.data_dir = "." if data_dir is None else data_dir
 
     @staticmethod
     def load_toml(path: str):
@@ -93,7 +95,7 @@ class Testnet:
             Node(
                 f"node-{i}",
                 self.chain_id,
-                f"node-{i}",
+                f"{self.data_dir}/node-{i}",
                 overwrite=self.overwrite,
                 keep=self.keep,
                 binary=self.binary,
@@ -189,6 +191,7 @@ class Testnet:
                 gentx_file = glob.glob(f"{node.home_dir}/config/gentx/*json")[0].split(
                     "/", maxsplit=1
                 )[-1]
+                gentx_file = gentx_file.lstrip(node.home_dir)
                 node_p2p = node.get(p2p.config_file, p2p.property_path).rsplit(
                     ":", maxsplit=1
                 )[-1]

--- a/atomkraft/chain/testnet.py
+++ b/atomkraft/chain/testnet.py
@@ -43,7 +43,7 @@ class Testnet:
         self.validator_balance = validator_balance
         self.overwrite = overwrite
         self.keep = keep
-        self._verbose = verbose
+        self.verbose = verbose
 
     @staticmethod
     def load_toml(path: str):
@@ -154,7 +154,7 @@ class Testnet:
                 port_data.append(node.get(e_port.config_file, e_port.property_path))
             all_port_data.append(port_data)
 
-        if self._verbose:
+        if self.verbose:
             print(
                 tabulate.tabulate(
                     all_port_data,

--- a/atomkraft/cli/__init__.py
+++ b/atomkraft/cli/__init__.py
@@ -21,12 +21,14 @@ GH_TEMPLATE = "gh:informalsystems/atomkraft"
 
 
 @app.command()
-def init(path: Path):
+def init(
+    name: Path = typer.Argument(..., help="Name of new directory", show_default=False)
+):
     """
     Initialize new Atomkraft project in the given directory
     """
-    git.Repo.init(path)
-    run_auto(GH_TEMPLATE, path, vcs_ref="rano/impl-adr02")
+    git.Repo.init(name)
+    run_auto(GH_TEMPLATE, name, vcs_ref="rano/impl-adr02")
 
 
 app.add_typer(


### PR DESCRIPTION
Closes #33 

Stores chain validator node data in `.atomkraft` directory.