### PR TITLE
`test trace` command: execute a trace against testnet

### DIFF
--- a/atomkraft/cli/__init__.py
+++ b/atomkraft/cli/__init__.py
@@ -13,6 +13,7 @@ app = typer.Typer(
     add_completion=False,
     name="atomkraft",
     no_args_is_help=True,
+    rich_markup_mode="rich",
 )
 
 GH_TEMPLATE = "gh:informalsystems/atomkraft"
@@ -20,7 +21,6 @@ GH_TEMPLATE = "gh:informalsystems/atomkraft"
 
 @app.command(
     no_args_is_help=True,
-
 )
 def init(
     name: Path = typer.Argument(..., help="Name of new directory", show_default=False)

--- a/atomkraft/reactor/reactor.py
+++ b/atomkraft/reactor/reactor.py
@@ -3,6 +3,7 @@ from os import PathLike
 import os
 from typing import List, Optional
 import tomlkit
+from caseconverter import snakecase
 from . import constants
 from . import utils
 from .step_functions_visitor import StepFunctionsVisitor
@@ -108,8 +109,8 @@ def _keypath_stub(keypath):
 
 def _action_stub(action_name: str, variables: List[str]):
     stub = f"""
-@step({action_name})
-def {action_name}(testnet, state, {", ".join(variables)}):
+@step({repr(action_name)})
+def {snakecase(action_name)}(testnet, state, {", ".join(variables)}):
     print("Step: {action_name}")
 """
     return stub

--- a/atomkraft/reactor/reactor.py
+++ b/atomkraft/reactor/reactor.py
@@ -108,8 +108,8 @@ def _keypath_stub(keypath):
 
 def _action_stub(action_name: str, variables: List[str]):
     stub = f"""
-@step({repr(action_name)})
-def act_step(testnet, state, {", ".join(variables)}):
+@step({action_name})
+def {action_name}(testnet, state, {", ".join(variables)}):
     print("Step: {action_name}")
 """
     return stub

--- a/atomkraft/reactor/reactor.py
+++ b/atomkraft/reactor/reactor.py
@@ -1,6 +1,7 @@
 import ast
 from os import PathLike
 import os
+import os.path
 from typing import List, Optional
 import tomlkit
 from caseconverter import snakecase
@@ -41,18 +42,30 @@ def get_reactor() -> PathLike:
     returns the path to the current reactor from the internal config
     """
 
-    if "PYTEST_CURRENT_TEST" in os.environ:
-        root = "tests/project"
-    else:
-        root = project_root()
+    root = project_root()
+
+    if not root:
+        raise RuntimeError(
+            "could not find Atomkraft project: are you in the right directory?"
+        )
 
     internal_config_file_path = os.path.join(
         root,
         constants.ATOMKRAFT_INTERNAL_FOLDER,
         constants.ATOMKRAFT_INTERNAL_CONFIG,
     )
+
+    if not os.path.isfile(internal_config_file_path):
+        raise RuntimeError(
+            "Atomkraft configuration not found: have you executed `atomkraft init`?"
+        )
+
     with open(internal_config_file_path) as config_f:
         config_data = tomlkit.load(config_f)
+        if constants.REACTOR_CONFIG_KEY not in config_data:
+            raise RuntimeError(
+                "Could not find default reactor; have you ran `atomkraft reactor`?"
+            )
         return config_data[constants.REACTOR_CONFIG_KEY]
 
 

--- a/atomkraft/test/__init__.py
+++ b/atomkraft/test/__init__.py
@@ -37,7 +37,7 @@ def trace(
     Test blockchain by running one trace
     """
 
-    test_trace(trace.name, reactor.name, keypath)
+    test_trace(trace.name, reactor if reactor is None else reactor.name, keypath)
 
 
 @app.command()

--- a/atomkraft/test/__init__.py
+++ b/atomkraft/test/__init__.py
@@ -1,5 +1,6 @@
 from typing import List, Optional
 import typer
+from .trace import test_trace
 
 app = typer.Typer(rich_markup_mode="rich", add_completion=False)
 
@@ -12,20 +13,31 @@ def FileOption(help, default):
     )
 
 
+def RequiredFileOption(help, default):
+    return typer.Option(
+        ...,
+        show_default=False,
+        help=f"{help} [grey30]\[default: set via [bold cyan]atomkraft {default}[/bold cyan]][/grey30]",
+    )
+
+
 @app.command()
 def trace(
-    trace: typer.FileText = FileOption("trace to execute", "model"),
+    # currently, require the trace to be present.
+    # later, there will be an option to pick up the last one from the model
+    trace: typer.FileText = RequiredFileOption("trace to execute", "model"),
     reactor: typer.FileText = FileOption("reactor to interpret the trace", "reactor"),
+    keypath: str = typer.Option(
+        "action",
+        show_default=True,
+        help=f"Path to key used as step name, extracted from ITF states",
+    ),
 ):
     """
     Test blockchain by running one trace
     """
-    print(
-        f"""
-    Trace: {trace}
-    Reactor: {reactor}
-    """
-    )
+
+    test_trace(trace.name, reactor.name, keypath)
 
 
 @app.command()

--- a/atomkraft/test/trace.py
+++ b/atomkraft/test/trace.py
@@ -6,7 +6,7 @@ import pytest
 from ..reactor.reactor import get_reactor
 
 
-trace_test_stub = """
+TRACE_TEST_STUB = """
 from modelator.pytest.decorators import itf
 
 pytest_plugins = "{0}"
@@ -49,8 +49,8 @@ def test_trace(trace: PathLike, reactor: PathLike, keypath: str):
     with open(test_path, "w") as test:
         print(f"Writing {test_name} ...")
         test.write(
-            trace_test_stub.format(
-                str(reactor).replace("/", ".").replace(".py", ""), trace, keypath
+            TRACE_TEST_STUB.format(
+                str(reactor).replace("/", ".").removesuffix(".py"), trace, keypath
             )
         )
     print(f"Executing {test_name} ...")

--- a/atomkraft/test/trace.py
+++ b/atomkraft/test/trace.py
@@ -2,6 +2,8 @@ from os import PathLike
 from atomkraft.utils.project import project_root
 import os.path
 from datetime import datetime
+import pytest
+from ..reactor.reactor import get_reactor
 
 
 trace_test_stub = """
@@ -19,6 +21,9 @@ def test_trace(trace: PathLike, reactor: PathLike, keypath: str):
     """
     Test blockchain by running one trace
     """
+
+    if reactor is None:
+        reactor = get_reactor()
 
     root = project_root()
     if not root:
@@ -40,10 +45,13 @@ def test_trace(trace: PathLike, reactor: PathLike, keypath: str):
         .replace(":", "_")
         .replace("-", "_")
     )
-    test = os.path.join(tests, f"{test_name}.py")
-    with open(test, "w") as test:
+    test_path = os.path.join(tests, f"{test_name}.py")
+    with open(test_path, "w") as test:
+        print(f"Writing {test_name} ...")
         test.write(
             trace_test_stub.format(
                 str(reactor).replace("/", ".").replace(".py", ""), trace, keypath
             )
         )
+    print(f"Executing {test_name} ...")
+    pytest.main(["-s", test_path])

--- a/atomkraft/test/trace.py
+++ b/atomkraft/test/trace.py
@@ -1,0 +1,49 @@
+from os import PathLike
+from atomkraft.utils.project import project_root
+import os.path
+from datetime import datetime
+
+
+trace_test_stub = """
+from modelator.pytest.decorators import itf
+
+pytest_plugins = "{0}"
+
+@itf("{1}", keypath="{2}")
+def test_trace():
+    print("Successfully executed trace {1}")
+"""
+
+
+def test_trace(trace: PathLike, reactor: PathLike, keypath: str):
+    """
+    Test blockchain by running one trace
+    """
+
+    root = project_root()
+    if not root:
+        raise RuntimeError(
+            "could not find Atomkraft project: are you in the right directory?"
+        )
+
+    tests = os.path.join(root, "tests")
+    if not os.path.isdir(tests):
+        raise RuntimeError(
+            "Atomkraft tests directory not found: have you executed `atomkraft init`?"
+        )
+
+    timestamp = datetime.now().isoformat(timespec="milliseconds")
+    test_name = f"test_{str(trace)}_{timestamp}"
+    test_name = (
+        test_name.replace("/", "_")
+        .replace(".", "_")
+        .replace(":", "_")
+        .replace("-", "_")
+    )
+    test = os.path.join(tests, f"{test_name}.py")
+    with open(test, "w") as test:
+        test.write(
+            trace_test_stub.format(
+                str(reactor).replace("/", ".").replace(".py", ""), trace, keypath
+            )
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ toml = "^0.10.2"
 GitPython = "^3.1.27"
 tomlkit = "^0.11.1"
 munch = "^2.5.0"
+case-converter = "^1.1.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0", "setuptools>=42"]


### PR DESCRIPTION
Closes #27

This PR implements `atomkraft test trace` command
  - `trace` option is required now, until #55 is implemented
  - generates a new Pytest file, referencing the trace, the supplied / stored reactor
  - stores the test file in the `tests` dir
  - invokes Pytest on the new file.

This PR leaves for future work:
- retrieving and storing blockchain logs
- retrieving and storing test execution results 
- tests for the above functionality