### PR TITLE
Add classes to handle config files

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip
+      - run: python -m pip install pyflakes==2.4.0
       - run: python -m pip install black pylama[all]
       - run: |
           black . --check

--- a/atomkraft/config/atomkraft_config.py
+++ b/atomkraft/config/atomkraft_config.py
@@ -10,7 +10,6 @@ ATOMKRAFT_INTERNAL_CONFIG = "config.toml"
 
 
 class AtomkraftConfig(ConfigFile):
-
     def __init__(self, path: Optional[str] = None):
         if not path:
             if "PYTEST_CURRENT_TEST" in os.environ:

--- a/atomkraft/config/atomkraft_config.py
+++ b/atomkraft/config/atomkraft_config.py
@@ -1,5 +1,6 @@
 import os
 from typing import Optional
+
 from atomkraft.config.config_file import ConfigFile
 from atomkraft.utils.project import project_root
 

--- a/atomkraft/config/atomkraft_config.py
+++ b/atomkraft/config/atomkraft_config.py
@@ -1,0 +1,25 @@
+import os
+from typing import Optional
+from atomkraft.config.config_file import ConfigFile
+from atomkraft.utils.project import project_root
+
+ATOMKRAFT_INTERNAL_DIR = ".atomkraft"
+
+# the file that contains internal configurations for atomkraft
+ATOMKRAFT_INTERNAL_CONFIG = "config.toml"
+
+
+class AtomkraftConfig(ConfigFile):
+
+    def __init__(self, path: Optional[str] = None):
+        if not path:
+            if "PYTEST_CURRENT_TEST" in os.environ:
+                root = "tests/project"
+            else:
+                root = project_root()
+            self.path = os.path.join(
+                root,
+                ATOMKRAFT_INTERNAL_DIR,
+                ATOMKRAFT_INTERNAL_CONFIG,
+            )
+        super(path)

--- a/atomkraft/config/atomkraft_config.py
+++ b/atomkraft/config/atomkraft_config.py
@@ -13,8 +13,8 @@ ATOMKRAFT_INTERNAL_CONFIG = "config.toml"
 class AtomkraftConfig(ConfigFile):
     def __init__(self, path: Optional[str] = None):
         if not path:
-            if "PYTEST_CURRENT_TEST" in os.environ:
-                root = "tests/project"
+            if "PROJECT_ROOT" in os.environ:
+                root = os.environ["PROJECT_ROOT"]
             else:
                 root = project_root()
             path = os.path.join(

--- a/atomkraft/config/atomkraft_config.py
+++ b/atomkraft/config/atomkraft_config.py
@@ -16,9 +16,9 @@ class AtomkraftConfig(ConfigFile):
                 root = "tests/project"
             else:
                 root = project_root()
-            self.path = os.path.join(
+            path = os.path.join(
                 root,
                 ATOMKRAFT_INTERNAL_DIR,
                 ATOMKRAFT_INTERNAL_CONFIG,
             )
-        super(path)
+        super().__init__(path)

--- a/atomkraft/config/chain_config.py
+++ b/atomkraft/config/chain_config.py
@@ -10,8 +10,8 @@ CHAIN_CONFIG_PATH = "chain.toml"
 class ChainConfig(ConfigFile):
     def __init__(self, path: Optional[str] = None):
         if not path:
-            if "PYTEST_CURRENT_TEST" in os.environ:
-                root = "tests/project"
+            if "PROJECT_ROOT" in os.environ:
+                root = os.environ["PROJECT_ROOT"]
             else:
                 root = project_root()
             path = os.path.join(root, CHAIN_CONFIG_PATH)

--- a/atomkraft/config/chain_config.py
+++ b/atomkraft/config/chain_config.py
@@ -1,5 +1,6 @@
 import os
 from typing import Optional
+
 from atomkraft.config.config_file import ConfigFile
 from atomkraft.utils.project import project_root
 

--- a/atomkraft/config/chain_config.py
+++ b/atomkraft/config/chain_config.py
@@ -14,4 +14,4 @@ class ChainConfig(ConfigFile):
             else:
                 root = project_root()
             path = os.path.join(root, CHAIN_CONFIG_PATH)
-        super(path)
+        super().__init__(path)

--- a/atomkraft/config/chain_config.py
+++ b/atomkraft/config/chain_config.py
@@ -1,0 +1,17 @@
+import os
+from typing import Optional
+from atomkraft.config.config_file import ConfigFile
+from atomkraft.utils.project import project_root
+
+CHAIN_CONFIG_PATH = "chain.toml"
+
+class ChainConfig(ConfigFile):
+
+    def __init__(self, path: Optional[str] = None):
+        if not path:
+            if "PYTEST_CURRENT_TEST" in os.environ:
+                root = "tests/project"
+            else:
+                root = project_root()
+            self.path = os.path.join(root, CHAIN_CONFIG_PATH)
+        super(path)

--- a/atomkraft/config/chain_config.py
+++ b/atomkraft/config/chain_config.py
@@ -5,8 +5,8 @@ from atomkraft.utils.project import project_root
 
 CHAIN_CONFIG_PATH = "chain.toml"
 
-class ChainConfig(ConfigFile):
 
+class ChainConfig(ConfigFile):
     def __init__(self, path: Optional[str] = None):
         if not path:
             if "PYTEST_CURRENT_TEST" in os.environ:

--- a/atomkraft/config/chain_config.py
+++ b/atomkraft/config/chain_config.py
@@ -13,5 +13,5 @@ class ChainConfig(ConfigFile):
                 root = "tests/project"
             else:
                 root = project_root()
-            self.path = os.path.join(root, CHAIN_CONFIG_PATH)
+            path = os.path.join(root, CHAIN_CONFIG_PATH)
         super(path)

--- a/atomkraft/config/config_file.py
+++ b/atomkraft/config/config_file.py
@@ -1,14 +1,14 @@
 import tomlkit
 
 
-class ConfigFile:
+class ConfigFile(object):
     def __init__(self, path: str):
         self.data = {}
         self.path = path
 
     def __enter__(self):
         self.fd = open(self.path, "w+")
-        self.data = tomlkit.load(self.fg)
+        self.data = tomlkit.load(self.fd)
         return self
 
     def __exit__(self, type, value, traceback):

--- a/atomkraft/config/config_file.py
+++ b/atomkraft/config/config_file.py
@@ -15,13 +15,9 @@ class ConfigFile(object):
         self.fd.close()
 
     def get(self, key) -> str:
-        if key in self.data:
-            return self.data[key]
-        if key.replace("-", "_") in self.data:
-            return self.data[key.replace("-", "_")]
-        if key.replace("_", "-") in self.data:
-            return self.data[key.replace("_", "-")]
-        raise KeyError
+        if key not in self.data:
+            raise KeyError
+        return self.data[key]
 
     def write(self, key, value):
         self.data[key] = value

--- a/atomkraft/config/config_file.py
+++ b/atomkraft/config/config_file.py
@@ -1,0 +1,28 @@
+import tomlkit
+
+
+class ConfigFile:
+    def __init__(self, path: str):
+        self.data = {}
+        self.path = path
+
+    def __enter__(self):
+        self.fd = open(self.path, 'w+')
+        self.data = tomlkit.load(self.fg)
+        return self
+    
+    def __exit__(self, type, value, traceback):
+        self.fd.close()
+    
+    def get(self, key) -> str:
+        if key in self.data:
+            return self.data[key]        
+        if key.replace("-", "_") in self.data:
+            return self.data[key.replace("-", "_")]
+        if key.replace("_", "-") in self.data:
+            return self.data[key.replace("_", "-")]
+        raise KeyError
+
+    def write(self, key, value):
+        self.data[key] = value
+        tomlkit.dump(self.data, self.fd)

--- a/atomkraft/config/config_file.py
+++ b/atomkraft/config/config_file.py
@@ -14,11 +14,11 @@ class ConfigFile(object):
     def __exit__(self, type, value, traceback):
         self.fd.close()
 
-    def get(self, key) -> str:
+    def query(self, key) -> str:
         if key not in self.data:
             raise KeyError
         return self.data[key]
 
-    def write(self, key, value):
+    def store(self, key, value):
         self.data[key] = value
         tomlkit.dump(self.data, self.fd)

--- a/atomkraft/config/config_file.py
+++ b/atomkraft/config/config_file.py
@@ -7,16 +7,16 @@ class ConfigFile:
         self.path = path
 
     def __enter__(self):
-        self.fd = open(self.path, 'w+')
+        self.fd = open(self.path, "w+")
         self.data = tomlkit.load(self.fg)
         return self
-    
+
     def __exit__(self, type, value, traceback):
         self.fd.close()
-    
+
     def get(self, key) -> str:
         if key in self.data:
-            return self.data[key]        
+            return self.data[key]
         if key.replace("-", "_") in self.data:
             return self.data[key.replace("-", "_")]
         if key.replace("_", "-") in self.data:

--- a/atomkraft/config/model_config.py
+++ b/atomkraft/config/model_config.py
@@ -5,8 +5,8 @@ from atomkraft.utils.project import project_root
 
 MODEL_CONFIG_PATH = "model.toml"
 
-class ModelConfig(ConfigFile):
 
+class ModelConfig(ConfigFile):
     def __init__(self, path: Optional[str] = None):
         if not path:
             if "PYTEST_CURRENT_TEST" in os.environ:

--- a/atomkraft/config/model_config.py
+++ b/atomkraft/config/model_config.py
@@ -1,5 +1,6 @@
 import os
 from typing import Optional
+
 from atomkraft.config.config_file import ConfigFile
 from atomkraft.utils.project import project_root
 

--- a/atomkraft/config/model_config.py
+++ b/atomkraft/config/model_config.py
@@ -13,5 +13,5 @@ class ModelConfig(ConfigFile):
                 root = "tests/project"
             else:
                 root = project_root()
-            self.path = os.path.join(root, MODEL_CONFIG_PATH)
+            path = os.path.join(root, MODEL_CONFIG_PATH)
         super(path)

--- a/atomkraft/config/model_config.py
+++ b/atomkraft/config/model_config.py
@@ -10,8 +10,8 @@ MODEL_CONFIG_PATH = "model.toml"
 class ModelConfig(ConfigFile):
     def __init__(self, path: Optional[str] = None):
         if not path:
-            if "PYTEST_CURRENT_TEST" in os.environ:
-                root = "tests/project"
+            if "PROJECT_ROOT" in os.environ:
+                root = os.environ["PROJECT_ROOT"]
             else:
                 root = project_root()
             path = os.path.join(root, MODEL_CONFIG_PATH)

--- a/atomkraft/config/model_config.py
+++ b/atomkraft/config/model_config.py
@@ -1,0 +1,17 @@
+import os
+from typing import Optional
+from atomkraft.config.config_file import ConfigFile
+from atomkraft.utils.project import project_root
+
+MODEL_CONFIG_PATH = "model.toml"
+
+class ModelConfig(ConfigFile):
+
+    def __init__(self, path: Optional[str] = None):
+        if not path:
+            if "PYTEST_CURRENT_TEST" in os.environ:
+                root = "tests/project"
+            else:
+                root = project_root()
+            self.path = os.path.join(root, MODEL_CONFIG_PATH)
+        super(path)

--- a/atomkraft/config/model_config.py
+++ b/atomkraft/config/model_config.py
@@ -14,4 +14,4 @@ class ModelConfig(ConfigFile):
             else:
                 root = project_root()
             path = os.path.join(root, MODEL_CONFIG_PATH)
-        super(path)
+        super().__init__(path)

--- a/atomkraft/reactor/constants.py
+++ b/atomkraft/reactor/constants.py
@@ -1,8 +1,3 @@
-ATOMKRAFT_INTERNAL_FOLDER = ".atomkraft"
-
-# the file that contains internal configurations for atomkraft
-ATOMKRAFT_INTERNAL_CONFIG = "config.toml"
-
 # a key for the reactor path inside internal config
 REACTOR_CONFIG_KEY = "reactor"
 

--- a/atomkraft/reactor/reactor.py
+++ b/atomkraft/reactor/reactor.py
@@ -68,6 +68,7 @@ def get_reactor() -> PathLike:
                 "Could not find default reactor; have you ran `atomkraft reactor`?"
             )
 
+
 def generate_reactor(
     actions_list: List[str],
     variables_list: List[str],

--- a/atomkraft/reactor/reactor.py
+++ b/atomkraft/reactor/reactor.py
@@ -62,7 +62,7 @@ def get_reactor() -> PathLike:
 
     with AtomkraftConfig() as config:
         try:
-            return config.get(constants.REACTOR_CONFIG_KEY)
+            return config.query(constants.REACTOR_CONFIG_KEY)
         except KeyError:
             raise RuntimeError(
                 "Could not find default reactor; have you ran `atomkraft reactor`?"
@@ -93,7 +93,7 @@ def generate_reactor(
         f.write(actions_stub)
 
     with AtomkraftConfig() as config:
-        config.write(constants.REACTOR_CONFIG_KEY, stub_file_path)
+        config.store(constants.REACTOR_CONFIG_KEY, stub_file_path)
 
     return stub_file_path
 

--- a/atomkraft/reactor/reactor.py
+++ b/atomkraft/reactor/reactor.py
@@ -4,9 +4,9 @@ import os.path
 from os import PathLike
 from typing import List, Optional
 
+from atomkraft.config.atomkraft_config import AtomkraftConfig
 from atomkraft.utils.project import project_root
 from caseconverter import snakecase
-from atomkraft.config.atomkraft_config import AtomkraftConfig
 
 from . import constants, utils
 from .step_functions_visitor import StepFunctionsVisitor

--- a/atomkraft/reactor/reactor.py
+++ b/atomkraft/reactor/reactor.py
@@ -4,9 +4,9 @@ import os.path
 from os import PathLike
 from typing import List, Optional
 
-import tomlkit
 from atomkraft.utils.project import project_root
 from caseconverter import snakecase
+from atomkraft.config.atomkraft_config import AtomkraftConfig
 
 from . import constants, utils
 from .step_functions_visitor import StepFunctionsVisitor
@@ -42,7 +42,6 @@ def get_reactor() -> PathLike:
     """
     returns the path to the current reactor from the internal config
     """
-
     root = project_root()
 
     if not root:
@@ -61,14 +60,13 @@ def get_reactor() -> PathLike:
             "Atomkraft configuration not found: have you executed `atomkraft init`?"
         )
 
-    with open(internal_config_file_path) as config_f:
-        config_data = tomlkit.load(config_f)
-        if constants.REACTOR_CONFIG_KEY not in config_data:
+    with AtomkraftConfig() as config:
+        try:
+            return config.get(constants.REACTOR_CONFIG_KEY)
+        except KeyError:
             raise RuntimeError(
                 "Could not find default reactor; have you ran `atomkraft reactor`?"
             )
-        return config_data[constants.REACTOR_CONFIG_KEY]
-
 
 def generate_reactor(
     actions_list: List[str],
@@ -93,22 +91,8 @@ def generate_reactor(
         f.write(state_stub)
         f.write(actions_stub)
 
-    if "PYTEST_CURRENT_TEST" in os.environ:
-        root = "tests/project"
-    else:
-        root = project_root()
-
-    internal_config_file_path = os.path.join(
-        root,
-        constants.ATOMKRAFT_INTERNAL_FOLDER,
-        constants.ATOMKRAFT_INTERNAL_CONFIG,
-    )
-
-    atomkraft_internal_config = tomlkit.load(open(internal_config_file_path))
-    atomkraft_internal_config[constants.REACTOR_CONFIG_KEY] = stub_file_path
-
-    with open(internal_config_file_path, "w") as internal_config_f:
-        tomlkit.dump(atomkraft_internal_config, internal_config_f)
+    with AtomkraftConfig() as config:
+        config.write(constants.REACTOR_CONFIG_KEY, stub_file_path)
 
     return stub_file_path
 

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,2 +1,2 @@
 [pylama]
-ignore = E501,C901,W0621
+ignore = E501,C901

--- a/pylama.ini
+++ b/pylama.ini
@@ -1,2 +1,2 @@
 [pylama]
-ignore = E501,C901
+ignore = E501,C901,W0621

--- a/template/model.toml
+++ b/template/model.toml
@@ -1,0 +1,14 @@
+[Model]
+model_path = "path/to/model.tla"
+# init = "Init"
+# next = "Next"
+# config_path = "path/to/module.cfg"
+# invariants = ["Inv1", "Inv2"]
+# examples = ["Ex1", "Ex2"]
+
+[Constants]
+# n = 42
+# foo = "bar"
+
+[Config]
+traces_dir = "traces/"

--- a/template/modelator.toml
+++ b/template/modelator.toml
@@ -1,8 +1,0 @@
-[[models]]
-model = "path/to/module.tla"
-config = "path/to/module.cfg"
-constants = {"N": 3, "FOO": "bar" }
-invariants = ["Inv1", "Inv2"]
-samples = ["Ex1", "Ex2"]
-md_monitor = "path/to/monitor.md"
-html_monitor = "path/to/monitor.html"

--- a/tests/test_reactor.py
+++ b/tests/test_reactor.py
@@ -1,3 +1,4 @@
+import os
 import py_compile
 
 from atomkraft.reactor import reactor
@@ -7,6 +8,7 @@ from atomkraft.reactor import reactor
 
 # test if a generated reactor is syntactically correct
 def test_parsing():
+    os.environ["PROJECT_ROOT"] = "tests/project"
     actions_list = [["action_1", "action_2"], [], ["act"]]
     variables_list = [["a", "b", "c", "d"], [], ["a"]]
     for actions in actions_list:
@@ -20,6 +22,7 @@ def test_parsing():
 
 
 def test_check():
+    os.environ["PROJECT_ROOT"] = "tests/project"
     actions = ["store_cw_contract", "instantiate", "get_count", "increment", "reset"]
     variables = ["owner", "instantiated", "stepCount", "messages", "count", "last_msg"]
     reactor_stub_file = "tests/project/reactors/check_correct_reactor.py"


### PR DESCRIPTION
This PR adds the base class `ConfigFile` which handles toml files, and additional classes that extend it: `AtomkraftConfig`, `ChainConfig` and `ModelConfig`. To see how they are used, check how `reactor/reactor.py` was refactored.