### PR TITLE
improve installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Testing for Cosmos Blockchains
 ### Using `pip` (inside a system or virtual env)
 
 ```
+git clone https://github.com/informalsystems/atomkraft.git
+cd atomkraft
 pip install atomkraft
 atomkraft --help
 # or
@@ -14,6 +16,9 @@ python -m atomkraft --help
 ### Using `poetry` (inside a project)
 
 ```
+git clone https://github.com/informalsystems/atomkraft.git
+cd atomkraft
+poetry install --no-interaction --no-root
 poetry add atomkraft
 poerty run atomkraft --help
 # or


### PR DESCRIPTION
I have tried to install atomkraft, and there were a few steps missing. Installation with `pip` worked fine, whereas `poetry` needed dependencies to be installed. Luckily, the CI had all required commands. This PR updates the installation instructions to reflect that.