### PR TITLE
pytest disable warnings

### DIFF
--- a/template/pytest.ini
+++ b/template/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-pythonpath =
-    .
+pythonpath = .
+addopts = --disable-warnings -p no:warnings


### PR DESCRIPTION
Disable unwanted warnings in `atomrkaft test trace ...`