### PR TITLE
Update tutorial with `cosmos-sdk` chain binary

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -39,15 +39,16 @@ Install `git` following [the installation instructions](https://git-scm.com/down
 
 If you are interested in Atomkraft, you probably want to test some Cosmos SDK blockchain; so, there is a high probability you have a blockchain binary in your system already. If this is the case, feel free skip the rest of this section.
 
-In case you don't have any Cosmos SDK blockchain binary locally, it should be easy to obtain it. The simplest solution if you want just to play with the tool is probably to use [Cosmos Hub (Gaia)](https://github.com/cosmos/gaia). You may either:
+In case you don't have any Cosmos SDK blockchain binary locally, it should be easy to obtain it. The simplest solution if you want just to play with the tool is to use [Cosmos-SDK](https://github.com/cosmos/cosmos-sdk). The blockchain binary can be compiled locally executing these following commands.
 
-- download a precompiled binary for you system from [Gaia releases](https://github.com/cosmos/gaia/releases), or
-- compile the blockchain binary locally
-  ```sh
-  git clone --depth 1 --branch v7.0.3 https://github.com/cosmos/gaia.git
-  (cd gaia; make build)
-  ```
-  The blockchain binary will be at `./gaia/build/gaiad`.
+```sh
+git clone --depth 1 --branch release/v0.45.x https://github.com/cosmos/cosmos-sdk
+(cd cosmos-sdk; make build)
+```
+
+The blockchain binary will be at `./cosmos-sdk/build/simd`.
+
+You may also install the compiled binary in your system (requires [setting up Go](https://go.dev/doc/install)), executing directly `(cd cosmos-sdk; make install)` instead of `(cd cosmos-sdk; make build)`.
 
 ## Java
 

--- a/examples/cosmos-sdk/transfer/transfer.md
+++ b/examples/cosmos-sdk/transfer/transfer.md
@@ -171,8 +171,14 @@ We will see how to extend the stub in section [Expanding reactors](#expanding-re
 Our ultimate goal is to execute tests on a chain.
 Now we set up the testnet to be used with Atomkraft.
 
-If you were following along the instructions in [INSTALLATION.md](/INSTALLATION.md), you are already have `gaiad` installed.
-Since `gaiad` is a default testnet in Atomkraft, there is nothing else to be done.
+If you were following along the instructions in [INSTALLATION.md](/INSTALLATION.md#blockchain-binary), you are already have `simd` compiled (or installed to system).
+`simd` is the default testnet in Atomkraft. If you have `simd` in your system path, there is nothing else to be done.
+
+Otherwise, you only need to set the chain binary path invoking:
+
+```
+atomkraft chain config binary <path-to-the-chain-binary>
+```
 
 Working with other chains is possible too, by installing them and then invoking:
 

--- a/examples/cosmos-sdk/transfer/transfer.md
+++ b/examples/cosmos-sdk/transfer/transfer.md
@@ -171,7 +171,7 @@ We will see how to extend the stub in section [Expanding reactors](#expanding-re
 Our ultimate goal is to execute tests on a chain.
 Now we set up the testnet to be used with Atomkraft.
 
-If you were following along the instructions in [INSTALLATION.md](/INSTALLATION.md#blockchain-binary), you are already have `simd` compiled (or installed to system).
+If you were following along the instructions in [INSTALLATION.md](/INSTALLATION.md#blockchain-binary), you already have `simd` compiled (or installed to system).
 `simd` is the default testnet in Atomkraft. If you have `simd` in your system path, there is nothing else to be done.
 
 Otherwise, you only need to set the chain binary path invoking:

--- a/template/chain.toml
+++ b/template/chain.toml
@@ -1,7 +1,7 @@
 chain_id = "cosmoshub-4"
 n_validator = 3
 n_account = 2
-binary = "gaiad"
+binary = "simd"
 prefix = "cosmos"
 denom = "stake"
 coin_type = 118


### PR DESCRIPTION
Replaced the instructions for `gaiad` with the instructions for `simd`.