### PR TITLE
Hide exception traceback

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -64,4 +64,4 @@ jobs:
       - name: Run tests
         run: |
           source .venv/bin/activate
-          pytest tests/
+          python -m pytest tests/

--- a/atomkraft/cli/__init__.py
+++ b/atomkraft/cli/__init__.py
@@ -123,7 +123,7 @@ def debug_callback(flag: bool):
 @app.callback()
 def main(
     ctx: typer.Context,
-    debug: bool = typer.Option(None, "debug", callback=debug_callback),
+    debug: bool = typer.Option(None, callback=debug_callback),
 ):
     if ctx.invoked_subcommand != "init":
         try:

--- a/atomkraft/cli/__init__.py
+++ b/atomkraft/cli/__init__.py
@@ -110,8 +110,21 @@ def reactor(
     generate_reactor(actions, variables, stub_file_path=path.name)
 
 
+def debug_callback(flag: bool):
+    if not flag:
+        app.pretty_exceptions_enable = False
+
+        def exception_handler(exception_type, exception, _):
+            print(f"{exception_type.__name__}: {exception}")
+
+        sys.excepthook = exception_handler
+
+
 @app.callback()
-def main(ctx: typer.Context, debug: bool = False):
+def main(
+    ctx: typer.Context,
+    debug: bool = typer.Option(None, "debug", callback=debug_callback),
+):
     if ctx.invoked_subcommand != "init":
         try:
             _ = project_root()
@@ -124,11 +137,3 @@ def main(ctx: typer.Context, debug: bool = False):
         except Exception as e:
             print(e)
             raise typer.Exit(1)
-
-    if not debug:
-        app.pretty_exceptions_enable = False
-
-        def exception_handler(exception_type, exception, _):
-            print(f"{exception_type.__name__}: {exception}")
-
-        sys.excepthook = exception_handler

--- a/atomkraft/cli/__init__.py
+++ b/atomkraft/cli/__init__.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pathlib import Path
 
 import git
@@ -110,7 +111,7 @@ def reactor(
 
 
 @app.callback()
-def main(ctx: typer.Context):
+def main(ctx: typer.Context, debug: bool = False):
     if ctx.invoked_subcommand != "init":
         try:
             _ = project_root()
@@ -123,3 +124,11 @@ def main(ctx: typer.Context):
         except Exception as e:
             print(e)
             raise typer.Exit(1)
+
+    if not debug:
+        app.pretty_exceptions_enable = False
+
+        def exception_handler(exception_type, exception, _):
+            print(f"{exception_type.__name__}: {exception}")
+
+        sys.excepthook = exception_handler


### PR DESCRIPTION
Closes #107

Usage

```
$ # without debug flag
$ atomkraft test trace ...
RuntimeError: Could not find default reactor; have you ran `atomkraft reactor`?
$ # with debug flag
$ atomkraft --debug test trace ...
...
│                                                                                                  │
│ ╭─────────────────────────────────────── locals ────────────────────────────────────────╮        │
│ │ config = <atomkraft.config.atomkraft_config.AtomkraftConfig object at 0x000000000000> │        │
│ ╰───────────────────────────────────────────────────────────────────────────────────────╯        │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
RuntimeError: Could not find default reactor; have you ran `atomkraft reactor`?
```

- [x] Rebase from `dev` after #108 is merged