### PR TITLE
Incremental output of compact summary of test progress and result

### DIFF
--- a/atomkraft/reactor/reactor.py
+++ b/atomkraft/reactor/reactor.py
@@ -133,8 +133,8 @@ def _action_stub(action_name: str, variables: List[str]):
 @step({repr(action_name)})
 def {snakecase(action_name)}(testnet, state, {", ".join(variables)}):
     {_action_description_comment(action_name, variables)}
-    #TODO: replace the printing stub with the effects of the action `{action_name}`
-    print("Step: {action_name}")
+    #TODO: replace the logging stub with the effects of the action `{action_name}`
+    logging.info("Step: {action_name}")
 """
     return stub
 
@@ -160,6 +160,8 @@ def state():
 
 def _imports_stub():
     stub = """
+import logging
+
 import pytest
 from modelator.pytest.decorators import step
 """

--- a/atomkraft/test/trace.py
+++ b/atomkraft/test/trace.py
@@ -76,13 +76,13 @@ def test_trace(trace: PathLike, reactor: PathLike, keypath: str, verbose: bool):
 
     pytest_args = [
         "--log-file-level=INFO",
+        "--log-cli-level=INFO",
         f"--log-file={logging_file}",
         f"--report-log={pytest_report_file}",
     ]
 
     if verbose:
         pytest_args.append("-rP")
-        pytest_args.append("--log-cli-level=INFO")
 
     pytest.main(pytest_args + [test_path])
 

--- a/examples/cosmos-sdk/transfer/reactor.py
+++ b/examples/cosmos-sdk/transfer/reactor.py
@@ -19,6 +19,8 @@ def init(testnet, action):
     testnet.oneshot()
     time.sleep(10)
 
+    logging.info("Status: Testnet launched")
+
 
 @step("Transfer")
 def transfer(testnet, action):
@@ -57,7 +59,18 @@ def transfer(testnet, action):
 
     result = lcdclient.tx.broadcast(tx)
 
-    logging.info(f"[MSG] {msg}")
-    logging.info(f"[RES] {result}")
+    logging.info(f"\tSender:    {msg.from_address}")
+    logging.info(f"\tReceiver:  {msg.to_address}")
+    logging.info(f"\tAmount:    {msg.amount}")
+
+    if result.code == 0:
+        logging.info("Status: Successful")
+    else:
+        logging.info("Status: Error")
+        logging.info(f"\tcode: {result.code}")
+        logging.info(f"\tlog:  {result.raw_log}")
+
+    logging.debug(f"[MSG] {msg}")
+    logging.debug(f"[RES] {result}")
 
     time.sleep(2)

--- a/examples/cosmos-sdk/transfer/reactor.py
+++ b/examples/cosmos-sdk/transfer/reactor.py
@@ -1,3 +1,4 @@
+import logging
 import time
 
 from modelator.pytest.decorators import step
@@ -11,7 +12,7 @@ from terra_sdk.key.mnemonic import MnemonicKey
 
 @step("Init")
 def init(testnet, action):
-    print("Step: Init")
+    logging.info("Step: Init")
     testnet.n_account = action["value"]["n_wallet"]
     testnet.verbose = True
 
@@ -21,7 +22,7 @@ def init(testnet, action):
 
 @step("Transfer")
 def transfer(testnet, action):
-    print("Step: Transfer")
+    logging.info("Step: Transfer")
 
     rest_endpoint = testnet.get_validator_port(0, "lcd")
     lcdclient = LCDClient(
@@ -56,7 +57,7 @@ def transfer(testnet, action):
 
     result = lcdclient.tx.broadcast(tx)
 
-    print("[MSG]", msg)
-    print("[RES]", result)
+    logging.info(f"[MSG] {msg}")
+    logging.info(f"[RES] {result}")
 
     time.sleep(2)

--- a/examples/cosmos-sdk/transfer/reactor.py
+++ b/examples/cosmos-sdk/transfer/reactor.py
@@ -19,7 +19,7 @@ def init(testnet, action):
     testnet.oneshot()
     time.sleep(10)
 
-    logging.info("Status: Testnet launched")
+    logging.info("Status: Testnet launched\n")
 
 
 @step("Transfer")
@@ -64,11 +64,11 @@ def transfer(testnet, action):
     logging.info(f"\tAmount:    {msg.amount}")
 
     if result.code == 0:
-        logging.info("Status: Successful")
+        logging.info("Status: Successful\n")
     else:
         logging.info("Status: Error")
         logging.info(f"\tcode: {result.code}")
-        logging.info(f"\tlog:  {result.raw_log}")
+        logging.info(f"\tlog:  {result.raw_log}\n")
 
     logging.debug(f"[MSG] {msg}")
     logging.debug(f"[RES] {result}")

--- a/examples/cosmos-sdk/transfer/transfer.md
+++ b/examples/cosmos-sdk/transfer/transfer.md
@@ -205,7 +205,7 @@ Successfully executed
 -->
 
 ```
-atomkraft test trace --trace traces/violation1.itf.json --reactor reactors/reactor.py --keypath action.tag --verbose
+atomkraft test trace --trace traces/violation1.itf.json --reactor reactors/reactor.py --keypath action.tag
 ```
 
 The output of the command contains
@@ -248,5 +248,5 @@ Successfully executed
 -->
 
 ```
-atomkraft test trace --trace traces/violation1.itf.json --reactor reactors/reactor.py --keypath action.tag --verbose
+atomkraft test trace --trace traces/violation1.itf.json --reactor reactors/reactor.py --keypath action.tag
 ```

--- a/tests/project/reactors/sample_reactor.py
+++ b/tests/project/reactors/sample_reactor.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from modelator.pytest.decorators import step
 
@@ -11,4 +13,4 @@ def state():
 
 @step()
 def act_step(chain_testnet, state, a):
-    print("Step: act")
+    logging.info("Step: act")


### PR DESCRIPTION
Closes #117

## Description

Incremental logging is enabled by default. I hardcoded `INFO` [level](https://docs.python.org/3/library/logging.html#logging-levels) to filter logs. Maybe a CLI argument would be the best.

Note, this will not print stdout incrementally (eg. content via `print()`). It will be printed at the end if `--verbose` flag is used.

## Example

Example output for `test trace` subcommand

```
tests/test_traces_violation1_itf_json_2022_08_31T15_01_54_103.py::test_trace 
----------------------------------------- live log call ------------------------------------------
INFO     root:reactor.py:15 Step: Init
INFO     root:reactor.py:22 Status: Testnet launched

INFO     root:reactor.py:27 Step: Transfer
INFO     root:reactor.py:62 	Sender:    cosmos1wxk5hdwvhsnk422kaqwuzfp2qljnsd23fpastt
INFO     root:reactor.py:63 	Receiver:  cosmos1udk2e7c78mxulv0ps4curqsw5ul5wtp7axm62e
INFO     root:reactor.py:64 	Amount:    0stake
INFO     root:reactor.py:69 Status: Error
INFO     root:reactor.py:70 	code: 10
INFO     root:reactor.py:71 	log:  0stake: invalid coins

INFO     root:reactor.py:27 Step: Transfer
INFO     root:reactor.py:62 	Sender:    cosmos1wxk5hdwvhsnk422kaqwuzfp2qljnsd23fpastt
INFO     root:reactor.py:63 	Receiver:  cosmos1udk2e7c78mxulv0ps4curqsw5ul5wtp7axm62e
INFO     root:reactor.py:64 	Amount:    1stake
INFO     root:reactor.py:67 Status: Successful

INFO     root:reactor.py:27 Step: Transfer
INFO     root:reactor.py:62 	Sender:    cosmos1udk2e7c78mxulv0ps4curqsw5ul5wtp7axm62e
INFO     root:reactor.py:63 	Receiver:  cosmos1wxk5hdwvhsnk422kaqwuzfp2qljnsd23fpastt
INFO     root:reactor.py:64 	Amount:    2stake
INFO     root:reactor.py:67 Status: Successful
```