### PR TITLE
ci(test): faster mdx ci runtime

### DIFF
--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: .venv
-          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+          key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('poetry.lock') }}
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
+        os: ["ubuntu-latest"]
         python-version: ["3.10"]
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -23,6 +23,12 @@ jobs:
       COSMOS_SDK_TAG: v0.45.8
     container: ghcr.io/rnbguy/mdx-docker:nightly
     steps:
+      - name: Restoring after GitHub default container params
+        run: |
+          echo "PATH=$PATH:/home/opam/.opam/4.14/bin" >> $GITHUB_ENV
+          ln -s "/__t" "/opt/hostedtoolcache"
+          mkdir -p /home/runner
+          ln -s "/__w" "/home/runner/work"
       - name: Check out repository
         uses: actions/checkout@v3
       - name: Set up python ${{ matrix.python-version }}

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Restoring after GitHub default container params
         run: |
-          echo "PATH=$PATH:/home/opam/.opam/4.14/bin" >> $GITHUB_ENV
+          echo "/home/opam/.opam/4.14/bin" >> $GITHUB_PATH
           ln -s "/__t" "/opt/hostedtoolcache"
           mkdir -p /home/runner
           ln -s "/__w" "/home/runner/work"
@@ -74,7 +74,7 @@ jobs:
           make build
       - name: Put Cosmos-SDK binary in system path
         run: |
-          echo "PATH=$PATH:$(pwd)/cosmos-sdk/build" >> $GITHUB_ENV
+          echo "$(pwd)/cosmos-sdk/build" >> $GITHUB_PATH
       - name: Setup Atomkraft and Apalache
         run: |
           source .venv/bin/activate

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       COSMOS_SDK_TAG: v0.45.8
+    container: ghcr.io/rnbguy/mdx-docker:nightly
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -48,12 +49,6 @@ jobs:
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
-      - name: Set up OCaml
-        uses: ocaml/setup-ocaml@v2
-        with:
-          ocaml-compiler: 4.13.x
-      - name: Install MDX
-        run: opam install mdx
       - name: Load cached simd
         id: cached-simd
         uses: actions/cache@v3
@@ -84,6 +79,5 @@ jobs:
         run: |
           source .venv/bin/activate
           cd tests/cli
-          eval $(opam env)
           sed -i.bu "s|/dev/|/${{ github.ref_name }}/|g" *md
           for f in `ls *md`; do ocaml-mdx test -v "${f}"; [ ! -f "${f}.corrected" ] || (diff -u "${f}" "${f}.corrected" && exit 1); done

--- a/.github/workflows/cli.yml
+++ b/.github/workflows/cli.yml
@@ -77,13 +77,13 @@ jobs:
           echo "$(pwd)/cosmos-sdk/build" >> $GITHUB_PATH
       - name: Setup Atomkraft and Apalache
         run: |
-          source .venv/bin/activate
+          . .venv/bin/activate
           poetry install --no-interaction
           python -m pip install pyflakes==2.4.0 black pylama[all]
           atomkraft model apalache get
       - name: Run tests
         run: |
-          source .venv/bin/activate
+          . .venv/bin/activate
           cd tests/cli
           sed -i.bu "s|/dev/|/${{ github.ref_name }}/|g" *md
           for f in `ls *md`; do ocaml-mdx test -v "${f}"; [ ! -f "${f}.corrected" ] || (diff -u "${f}" "${f}.corrected" && exit 1); done


### PR DESCRIPTION
- Runs jobs in docker container https://docs.github.com/en/actions/using-jobs/running-jobs-in-a-container
- Uses pre-built https://github.com/rnbguy/mdx-docker
- GitHub workflow mounts standard directories in non-standard places in docker, which messes up with some github-actions
-  macOS runner is disabled because it doesn't support docker