### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ python -m atomkraft --help
 
 ```
 poetry add atomkraft
-poerty run atomkraft --help
+poetry run atomkraft --help
 # or
 poetry run python -m atomkraft --help
 ```

--- a/examples/cosmos-sdk/transfer/transfer.md
+++ b/examples/cosmos-sdk/transfer/transfer.md
@@ -136,7 +136,7 @@ All three elements for running a test are now in place: a testnet, a test scenar
 Thus, we are ready to run some tests (though, trivial ones since the reactor is still only a stub).
 
 ```
-atomkraft test trace --path traces/TestALiceZero/violation1.itf.json --reactor reactors/reactor.py --keypath action.tag
+atomkraft test trace --path traces/TestAliceZero/violation1.itf.json --reactor reactors/reactor.py --keypath action.tag
 ```
 
 The output of the command contains


### PR DESCRIPTION
* A folder is created with lower case l, but then the command afterwards has upper case L
* poetry was misspelled poerty