### PR TITLE
imp: add bech32 address support for Ethermint chains 

### DIFF
--- a/atomkraft/chain/node.py
+++ b/atomkraft/chain/node.py
@@ -79,7 +79,7 @@ class Account:
         )
         self.coin_type = coin_type
         coin = supported_coins.setdefault(self.coin_type)
-        if coin == None:
+        if coin is None:
             raise ValueError(
                 f"Provided coin type {self.coin_type} not supported."
             )

--- a/atomkraft/chain/node.py
+++ b/atomkraft/chain/node.py
@@ -13,9 +13,10 @@ import hdwallet
 import numpy as np
 import tenacity
 import tomlkit
-from hdwallet.cryptocurrencies import Cryptocurrency, CoinType, EthereumMainnet
+from hdwallet.cryptocurrencies import CoinType, Cryptocurrency, EthereumMainnet
 
 from .. import utils
+
 
 @dataclass
 class ConfigPort:
@@ -71,7 +72,7 @@ class Account:
             np.random.default_rng(list(bytes(final_seed))).bytes(strength // 8).hex()
         )
         self.coin_type = coin_type
-        
+
         class LocalCC(Cryptocurrency):
             COIN_TYPE = CoinType({"INDEX": self.coin_type, "HARDENED": True})
         coin = LocalCC


### PR DESCRIPTION
## Description

This PR introduces the changes needed to make the proper bech32 address encoding to be able to use Atomkraft with Ethermint chains

Closes https://github.com/informalsystems/atomkraft/issues/211